### PR TITLE
Allow Substitute to not call block by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0 - 2023-03-29]
+### Changed
+- Don't call automatically yield in the repo, just when calling
+  set_reserved(true)
+
+
 ## [2.0.0 - 2022-12-09]
 ### Changed
-- Renamed gem and repo:
-  - from "idempotence" to "hubbado-idempotence-reservation"
+- Renamed gem and repo from "idempotence" to "hubbado-idempotence-reservation"
+
 
 ## [1.2.0 - 2022-11-29]
 ### Changed
 - Reserved metadata name is stored in metadata.local_properties
   instead of metadata.properties.
   metadata.local_properties is not followed so the info is not propagated to other messages
-  
+
 
 ## [1.1.0 - 2022-10-07]
 ### Added

--- a/hubbado-idempotence-reservation.gemspec
+++ b/hubbado-idempotence-reservation.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = "hubbado-idempotence-reservation"
-  spec.version  = "2.0.0"
+  spec.version  = "2.1.0"
   spec.authors  = ["Alfonso Uceda", "Sam Stickland", "Alexander Repnikov"]
   spec.email    = ["alfonso@hubbado.com", "sam@hubbado.com", "aleksander.repnikov@gmail.com"]
 

--- a/lib/idempotence/reservation/reservation.rb
+++ b/lib/idempotence/reservation/reservation.rb
@@ -108,11 +108,15 @@ module Idempotence
         attr_reader :message
         attr_reader :idempotence_key
 
-        def call(m, i_key, &block)
-          @message = m
-          @idempotence_key = i_key
+        def call(message, idempotence_key, &block)
+          @message = message
+          @idempotence_key = idempotence_key
 
-          yield message
+          yield message if @yield
+        end
+
+        def set_reserved(value)
+          @yield = value
         end
 
         def message?(value)

--- a/lib/idempotence/reservation/reservation.rb
+++ b/lib/idempotence/reservation/reservation.rb
@@ -107,16 +107,17 @@ module Idempotence
       class Reservation
         attr_reader :message
         attr_reader :idempotence_key
+        attr_reader :process_block
 
         def call(message, idempotence_key, &block)
           @message = message
           @idempotence_key = idempotence_key
 
-          yield message if @yield
+          yield message if @process_block
         end
 
         def set_reserved(value)
-          @yield = value
+          @process_block = value
         end
 
         def message?(value)

--- a/test/automated/reservation/substitute_test.rb
+++ b/test/automated/reservation/substitute_test.rb
@@ -13,9 +13,9 @@ context "Reservation" do
       block_message = m
     end
 
-    test "Block is called" do
-      assert(block_called)
-      assert(block_message == message)
+    test "Block is not called by default" do
+      refute(block_called)
+      refute(block_message == message)
     end
 
     test "Called with message" do
@@ -24,6 +24,20 @@ context "Reservation" do
 
     test "Called with idempotence_key" do
       assert(substitute.idempotence_key?(idempotence_key))
+    end
+
+    context "When set reserved" do
+      substitute.set_reserved(true)
+
+      substitute.(message, idempotence_key) do |m|
+        block_called = true
+        block_message = m
+      end
+
+      test "Block is called" do
+        assert(block_called)
+        assert(block_message == message)
+      end
     end
   end
 end

--- a/test/automated/reservation/substitute_test.rb
+++ b/test/automated/reservation/substitute_test.rb
@@ -8,9 +8,9 @@ context "Reservation" do
     idempotence_key = "Key"
 
     substitute = Reservation::Substitute.build
-    substitute.(message, idempotence_key) do |m|
+    substitute.(message, idempotence_key) do |msg|
       block_called = true
-      block_message = m
+      block_message = msg
     end
 
     test "Block is not called by default" do


### PR DESCRIPTION
Use .set_reserved(true) to test that the substitute executes the block