### PR TITLE
Gemfile declares a single global source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
-source "https://rubygems.pkg.github.com/hubbado"
 
 gemspec


### PR DESCRIPTION
CI has been red on master since 2026-02-12. It is not a test failure — the build never gets
that far.

## Root cause

The Gemfile declared two global sources:

```ruby
source "https://rubygems.org"
source "https://rubygems.pkg.github.com/hubbado"
```

`ruby/setup-ruby@v1` runs `bundle lock` during `bundler-cache: true`. Under Bundler 4 that is
refused:

```
This Gemfile contains multiple global sources. Each source after the first must
include a block to indicate which gems should come from that source
##[error]The process '.../bundle' failed with exit code 4
```

The workflow pins no `ruby-version`, so it takes the latest Ruby — currently 4.0.1, which
ships Bundler 4. That is what changed underneath this repo; the Gemfile had been tolerated by
Bundler 3.

## The fix

Drop the GitHub Packages source. Every dependency in the gemspec resolves on rubygems.org:

| Gem | Version on rubygems.org |
|---|---|
| evt-configure | 2.0.0.2 |
| evt-dependency | 2.2.0.0 |
| evt-log | 2.1.1.2 |
| evt-message_store | 2.4.0.1 |
| evt-messaging-postgres | 2.0.0.0 |
| evt-try | 2.0.0.0 |
| debug | 1.11.1 |
| test_bench | 3.0.0.0 |
| hubbado-style | 1.5.2 |

`hubbado-style` is the only one that looked private, and it is published publicly. `hubbado-log`
and `hubbado-types` already declare rubygems.org alone and both have green CI.

The alternative — keeping the second source inside a `source ... do ... end` block — would also
satisfy Bundler 4, but there is nothing left to put in the block.

## Verification

Run locally on Ruby 4.0.1 with Bundler 4.0.18, the same pairing CI resolves to:

- `bundle lock` succeeds where it previously exited 4
- `bundle install` succeeds
- `bundle exec ruby test/automated.rb` — 8 tests, 8 passed, 0 failed, 0 skipped

## Note

`ci.yml` still sets `BUNDLE_RUBYGEMS__PKG__GITHUB__COM` from secrets. It is now unused, but
harmless, and removing it is outside what this fix needs.

Once this lands, dependabot PR #9 should stop being blocked — its required check is this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYGiwM1prPXANzRjPq9tJh